### PR TITLE
SIMPLY-2536 Fix / silence Xcode 11.3.1 warnings

### DIFF
--- a/Platform/Apple/ePub3.xcodeproj/project.pbxproj
+++ b/Platform/Apple/ePub3.xcodeproj/project.pbxproj
@@ -1993,7 +1993,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../..\nsh MakeHeaders.sh Apple";
+			shellScript = "cd ${SRCROOT}/../..\nsh MakeHeaders.sh Apple\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -2350,6 +2350,7 @@
 		ABA4BAEC16ADF5A600161B77 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_WARN_UNREACHABLE_CODE = NO;
 				DSTROOT = /tmp/ePub3_iOS.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "../../ePub3-iOS/ePub3-iOS-Prefix.pch";
@@ -2357,6 +2358,7 @@
 					"$(inherited)",
 					"USING_ICU=0",
 				);
+				GCC_WARN_UNUSED_FUNCTION = NO;
 				HEADER_SEARCH_PATHS = (
 					/usr/include/libxml2,
 					"$(SRCROOT)/include",
@@ -2373,6 +2375,7 @@
 		ABA4BAED16ADF5A600161B77 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_WARN_UNREACHABLE_CODE = NO;
 				DSTROOT = /tmp/ePub3_iOS.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "../../ePub3-iOS/ePub3-iOS-Prefix.pch";
@@ -2380,6 +2383,7 @@
 					"$(inherited)",
 					"USING_ICU=0",
 				);
+				GCC_WARN_UNUSED_FUNCTION = NO;
 				HEADER_SEARCH_PATHS = (
 					/usr/include/libxml2,
 					"$(SRCROOT)/include",

--- a/Platform/Apple/ePub3.xcodeproj/project.pbxproj
+++ b/Platform/Apple/ePub3.xcodeproj/project.pbxproj
@@ -1944,15 +1944,16 @@
 		ABA72C1B1655382E003125FF /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0820;
+				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = "The Readium Foundation and contributors";
 			};
 			buildConfigurationList = ABA72C1E1655382E003125FF /* Build configuration list for PBXProject "ePub3" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = ABA72C191655382E003125FF;
 			productRefGroup = ABA72C251655382E003125FF /* Products */;
@@ -2325,6 +2326,7 @@
 		AB61CE521694845700299BB1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
 				HEADER_SEARCH_PATHS = (
 					/usr/include/libxml2,
 					"$(SRCROOT)/include",
@@ -2336,6 +2338,7 @@
 		AB61CE531694845700299BB1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
 				HEADER_SEARCH_PATHS = (
 					/usr/include/libxml2,
 					"$(SRCROOT)/include",
@@ -2347,7 +2350,6 @@
 		ABA4BAEC16ADF5A600161B77 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
 				DSTROOT = /tmp/ePub3_iOS.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "../../ePub3-iOS/ePub3-iOS-Prefix.pch";
@@ -2365,14 +2367,12 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				STRIP_INSTALLED_PRODUCT = NO;
-				VALID_ARCHS = "arm64 armv7s armv7";
 			};
 			name = Debug;
 		};
 		ABA4BAED16ADF5A600161B77 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
 				DSTROOT = /tmp/ePub3_iOS.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "../../ePub3-iOS/ePub3-iOS-Prefix.pch";
@@ -2391,7 +2391,6 @@
 				SKIP_INSTALL = YES;
 				STRIP_INSTALLED_PRODUCT = NO;
 				VALIDATE_PRODUCT = YES;
-				VALID_ARCHS = "arm64 armv7s armv7";
 			};
 			name = Release;
 		};
@@ -2401,12 +2400,21 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -2443,12 +2451,21 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;

--- a/Platform/Apple/ePub3.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Platform/Apple/ePub3.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Platform/Apple/ePub3.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/Platform/Apple/ePub3.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AB61CE491694845700299BB1"
+               BuildableName = "UnitTests"
+               BlueprintName = "UnitTests"
+               ReferencedContainer = "container:ePub3.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AB61CE491694845700299BB1"
+            BuildableName = "UnitTests"
+            BlueprintName = "UnitTests"
+            ReferencedContainer = "container:ePub3.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AB61CE491694845700299BB1"
+            BuildableName = "UnitTests"
+            BlueprintName = "UnitTests"
+            ReferencedContainer = "container:ePub3.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Platform/Apple/ePub3.xcodeproj/xcshareddata/xcschemes/ePub3-iOS.xcscheme
+++ b/Platform/Apple/ePub3.xcodeproj/xcshareddata/xcschemes/ePub3-iOS.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ABA4BADF16ADF5A600161B77"
+               BuildableName = "libePub3-iOS.a"
+               BlueprintName = "ePub3-iOS"
+               ReferencedContainer = "container:ePub3.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "ABA4BADF16ADF5A600161B77"
+            BuildableName = "libePub3-iOS.a"
+            BlueprintName = "ePub3-iOS"
+            ReferencedContainer = "container:ePub3.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Platform/Apple/ePub3.xcodeproj/xcshareddata/xcschemes/ePub3.xcscheme
+++ b/Platform/Apple/ePub3.xcodeproj/xcshareddata/xcschemes/ePub3.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ABA72C231655382E003125FF"
+               BuildableName = "ePub3.dylib"
+               BlueprintName = "ePub3"
+               ReferencedContainer = "container:ePub3.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "ABA72C231655382E003125FF"
+            BuildableName = "ePub3.dylib"
+            BlueprintName = "ePub3"
+            ReferencedContainer = "container:ePub3.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ePub3/ThirdParty/libzip/zip.h
+++ b/ePub3/ThirdParty/libzip/zip.h
@@ -194,7 +194,7 @@ ZIP_EXTERN struct zip_file *zip_fopen(struct zip *, const char *, int);
 ZIP_EXTERN struct zip_file *zip_fopen_index(struct zip *, int, int);
 ZIP_EXTERN ssize_t zip_fread(struct zip_file *, void *, size_t);
 ZIP_EXTERN int zip_fseek(struct zip_file*, long, int);
-ZIP_EXTERN long zip_ftell(struct zip_file*);
+ZIP_EXTERN off_t zip_ftell(struct zip_file*);
 ZIP_EXTERN const char *zip_get_archive_comment(struct zip *, int *, int);
 ZIP_EXTERN int zip_get_archive_flag(struct zip *, int, int);
 ZIP_EXTERN const char *zip_get_file_comment(struct zip *, int, int *, int);

--- a/ePub3/ThirdParty/libzip/zip_dirent.c
+++ b/ePub3/ThirdParty/libzip/zip_dirent.c
@@ -482,7 +482,7 @@ _zip_d2u_time(int dtime, int ddate)
 {
     struct tm tm;
 
-    memset(&tm, sizeof(tm), 0);
+    memset(&tm, 0, sizeof(tm));
     
     /* let mktime decide if DST is in effect */
     tm.tm_isdst = -1;

--- a/ePub3/ThirdParty/libzip/zip_fseek.c
+++ b/ePub3/ThirdParty/libzip/zip_fseek.c
@@ -114,7 +114,7 @@ int _zip_fseek_bytes(struct zip_file* zf, off_t abspos, off_t flen)
     /* not at or past EOF? ensure EOF is unset and update bytes_left */
     else {
         zf->flags &= ~ZIP_ZF_EOF;
-        zf->bytes_left = flen - abspos;
+        zf->bytes_left = (unsigned long)(flen - abspos);
     }
     zf->file_fpos = abspos;
     return 0;
@@ -132,7 +132,7 @@ int _zip_fseek_comp(struct zip_file* zf, off_t abspos, off_t flen)
     }
     else if (abspos > zf->file_fpos) {
         // read & decompress bytes until we reach the right position
-        return _zip_fseek_by_reading(zf, abspos-zf->file_fpos);
+        return _zip_fseek_by_reading(zf, (size_t)(abspos - zf->file_fpos));
     }
     
     /* at this point, we're definitely moving backwards */
@@ -147,7 +147,7 @@ int _zip_fseek_comp(struct zip_file* zf, off_t abspos, off_t flen)
         return -1;      /* error already set */
     
     /* this is a no-op for abspos == 0 */
-    return _zip_fseek_by_reading(zf, abspos);
+    return _zip_fseek_by_reading(zf, (size_t)abspos);
 }
 
 int _zip_fseek_to_start(struct zip_file* zf)

--- a/ePub3/ThirdParty/libzip/zip_ftell.c
+++ b/ePub3/ThirdParty/libzip/zip_ftell.c
@@ -34,7 +34,7 @@
 
 #include "zipint.h"
 
-ZIP_EXTERN long
+ZIP_EXTERN off_t
 zip_ftell(struct zip_file* zf)
 {
     if (!zf)

--- a/ePub3/ePub/archive.cpp
+++ b/ePub3/ePub/archive.cpp
@@ -67,7 +67,7 @@ ArchiveItemInfo Archive::InfoAtPath(const string &path) const
 {
     ArchiveItemInfo info;
     info.SetPath(path);
-    return std::move(info);
+    return info;
 }
 
 EPUB3_END_NAMESPACE

--- a/ePub3/ePub/cfi.h
+++ b/ePub3/ePub/cfi.h
@@ -53,7 +53,7 @@ public:
 public:
     ///
     /// Create an empty CFI.
-                    CFI() : _components(), _rangeStart(), _rangeEnd(), _options(0) {}
+                    CFI() : _components(), _options(0), _rangeStart(), _rangeEnd() {}
     /**
      Create a ranged CFI from a base and two relative CFIs.
      @param base A CFI consisting of components common to both the start and end of
@@ -71,7 +71,7 @@ public:
     EPUB3_EXPORT    CFI(const string& str);
     ///
     /// Create a copy of an existing CFI.
-                    CFI(const CFI& o) : _components(o._components), _rangeStart(o._rangeStart), _rangeEnd(o._rangeEnd), _options(o._options) {}
+                    CFI(const CFI& o) : _components(o._components), _options(o._options), _rangeStart(o._rangeStart), _rangeEnd(o._rangeEnd) {}
     /**
      Creates a relative CFI from a particular node index within another.
      
@@ -92,7 +92,7 @@ public:
     EPUB3_EXPORT    CFI(const CFI& o, size_t fromIndex);
     ///
     /// C++11 move constructor.
-    EPUB3_EXPORT    CFI(CFI&& o) : _components(std::move(o._components)), _rangeStart(std::move(o._rangeStart)), _rangeEnd(std::move(o._rangeEnd)), _options(o._options) {}
+    EPUB3_EXPORT    CFI(CFI&& o) : _components(std::move(o._components)), _options(o._options), _rangeStart(std::move(o._rangeStart)), _rangeEnd(std::move(o._rangeEnd)) {}
     virtual         ~CFI() {}
     
     /**

--- a/ePub3/ePub/content_module_manager.cpp
+++ b/ePub3/ePub/content_module_manager.cpp
@@ -68,7 +68,7 @@ future<ContainerPtr>
 ContentModuleManager::LoadContentAtPath(const string& path, launch policy)
 {
     std::unique_lock<std::mutex>(_mutex);
-    
+
     if (_known_modules.empty())
     {
         // special case for when we don't have any Content Modules to rely on for an initialized result

--- a/ePub3/ePub/content_module_manager.cpp
+++ b/ePub3/ePub/content_module_manager.cpp
@@ -45,7 +45,8 @@ ContentModuleManager* ContentModuleManager::Instance() _NOEXCEPT
 void ContentModuleManager::RegisterContentModule(std::shared_ptr<ContentModule> module,
                                                  const string& name) _NOEXCEPT
 {
-    std::unique_lock<std::mutex>(_mutex);
+    std::unique_lock<std::mutex> _(_mutex);
+
     _known_modules[name] = module;
 }
 
@@ -67,7 +68,7 @@ ContentModuleManager::RequestCredentialInput(const CredentialRequest &request)
 future<ContainerPtr>
 ContentModuleManager::LoadContentAtPath(const string& path, launch policy)
 {
-    std::unique_lock<std::mutex>(_mutex);
+    std::unique_lock<std::mutex> _(_mutex);
 
     if (_known_modules.empty())
     {

--- a/ePub3/ePub/epub_collection.cpp
+++ b/ePub3/ePub/epub_collection.cpp
@@ -18,7 +18,6 @@
 //  the License, or (at your option) any later version. You should have received a copy of the GNU 
 //  Affero General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#include "epub_collection.h"
 #include "package.h"
 #include <ePub3/epub3.h>
 #include <ePub3/utilities/error_handler.h>

--- a/ePub3/ePub/filter.h
+++ b/ePub3/ePub/filter.h
@@ -176,7 +176,7 @@ public:
             m_allocated_buffer_size = bytesToRead;
         }
 
-        for (int i = 0; i < m_allocated_buffer_size; i++)
+        for (ByteStream::size_type i = 0; i < m_allocated_buffer_size; i++)
         {
             m_buffer[i] = 0;
         }

--- a/ePub3/ePub/filter_manager_impl.h
+++ b/ePub3/ePub/filter_manager_impl.h
@@ -23,7 +23,14 @@
 
 #include <ePub3/filter_manager.h>
 #include <ePub3/filter.h>
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wuser-defined-warnings"
+#endif
 #include <set>
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 EPUB3_BEGIN_NAMESPACE
 

--- a/ePub3/ePub/link.cpp
+++ b/ePub3/ePub/link.cpp
@@ -19,7 +19,6 @@
 //  Affero General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "link.h"
-#include "epub_collection.h"
 #include "package.h"
 #include "manifest.h"
 #include <ePub3/utilities/error_handler.h>

--- a/ePub3/ePub/manifest.cpp
+++ b/ePub3/ePub/manifest.cpp
@@ -272,9 +272,9 @@ shared_ptr<xml::Document> ManifestItem::ReferencedDocument() const
 	
 	xmlDocPtr raw;
     if ( _mediaType == "text/html" ) {
-        raw = htmlReadMemory((const char*)docBuf, resbuflen, path.c_str(), encoding, flags);
+        raw = htmlReadMemory((const char*)docBuf, (int)resbuflen, path.c_str(), encoding, flags);
     } else {
-        raw = xmlReadMemory((const char*)docBuf, resbuflen, path.c_str(), encoding, flags);
+        raw = xmlReadMemory((const char*)docBuf, (int)resbuflen, path.c_str(), encoding, flags);
     }
 	
 	result = xml::Wrapped<xml::Document>(raw);

--- a/ePub3/ePub/package.cpp
+++ b/ePub3/ePub/package.cpp
@@ -932,7 +932,8 @@ bool Package::Unpack()
                     // user shouldn't have added manual things yet, but for safety we'll look anyway
                     for ( auto ptr : _contentHandlers[mediaType] )
                     {
-                        if ( typeid(*ptr) == typeid(MediaHandler) )
+                        const auto& mediaHandler = *ptr;
+                        if ( typeid(mediaHandler) == typeid(MediaHandler) )
                         {
                             HandleError(EPUBError::OPFMultipleBindingsForMediaType);
                         }
@@ -1728,7 +1729,8 @@ const Package::StringList Package::MediaTypesWithDHTMLHandlers() const
     {
         for ( auto pHandler : pair.second )
         {
-            if ( typeid(*pHandler) == typeid(MediaHandler) )
+            const auto& mediaHandler = *pHandler;
+            if ( typeid(mediaHandler) == typeid(MediaHandler) )
             {
                 result.emplace_back(pair.first);
                 break;

--- a/ePub3/ePub/package.h
+++ b/ePub3/ePub/package.h
@@ -365,7 +365,7 @@ private:
 
 public:
     EPUB3_EXPORT            Package(const shared_ptr<Container>& owner, const string& type);
-                            Package(Package&& o) : OwnedBy(std::move(o)), PackageBase(std::move(o)) {}
+                            Package(Package&& o) : PackageBase(std::move(o)), OwnedBy(std::move(o)) {}
     virtual                 ~Package() {}
     
     ContainerPtr            GetContainer()          const       { return Owner(); }

--- a/ePub3/ePub/package.h
+++ b/ePub3/ePub/package.h
@@ -39,7 +39,14 @@
 #include <ePub3/content_handler.h>
 #include <ePub3/media_support_info.h>
 #include <ePub3/property_holder.h>
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdefaulted-function-deleted"
+#endif
 #include <ePub3/epub_collection.h>
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #include <ePub3/utilities/xml_identifiable.h>
 #include <ePub3/utilities/string_view.h>
 //#include "media-overlays_smil_model.h"

--- a/ePub3/ePub/user_action.h
+++ b/ePub3/ePub/user_action.h
@@ -48,7 +48,7 @@ public:
     UserAction(ConstManifestItemPtr item,
                const CFI& cfi,
                ActionType type=ActionType::Display)
-        : m_item(item), m_cfi(cfi), m_type(type)
+        : m_type(type), m_cfi(cfi), m_item(item)
         {}
     virtual ~UserAction()
         {}

--- a/ePub3/ePub/zip_archive.h
+++ b/ePub3/ePub/zip_archive.h
@@ -68,21 +68,21 @@ public:
     
     virtual void EachItem(std::function<void(const ArchiveItemInfo&)> fn) const OVERRIDE;
     
-    virtual bool ContainsItem(const string & path) const;
-    virtual bool DeleteItem(const string & path);
+    virtual bool ContainsItem(const string & path) const OVERRIDE;
+    virtual bool DeleteItem(const string & path) OVERRIDE;
     
-    virtual bool CreateFolder(const string & path);
+    virtual bool CreateFolder(const string & path) OVERRIDE;
     
-    virtual unique_ptr<ByteStream> ByteStreamAtPath(const string& path) const;
+    virtual unique_ptr<ByteStream> ByteStreamAtPath(const string& path) const OVERRIDE;
 
 #ifdef SUPPORT_ASYNC
     virtual unique_ptr<AsyncByteStream> AsyncByteStreamAtPath(const string& path) const;
 #endif /* SUPPORT_ASYNC */
 
-    virtual unique_ptr<ArchiveReader> ReaderAtPath(const string & path) const;
-    virtual unique_ptr<ArchiveWriter> WriterAtPath(const string & path, bool compress=true, bool create=true);
+    virtual unique_ptr<ArchiveReader> ReaderAtPath(const string & path) const OVERRIDE;
+    virtual unique_ptr<ArchiveWriter> WriterAtPath(const string & path, bool compress=true, bool create=true) OVERRIDE;
         
-    virtual ArchiveItemInfo InfoAtPath(const string & path) const;
+    virtual ArchiveItemInfo InfoAtPath(const string & path) const OVERRIDE;
     
 protected:
     struct zip *    _zip;           ///< Pointer to the underlying `libzip` data type.

--- a/ePub3/utilities/byte_stream.h
+++ b/ePub3/utilities/byte_stream.h
@@ -530,14 +530,14 @@ private:
 public:
     ///
     /// @copydoc ByteStream::BytesAvailable()
-    virtual size_type       BytesAvailable()                        _NOEXCEPT;
+    virtual size_type       BytesAvailable()  _NOEXCEPT OVERRIDE;
     ///
     /// @copydoc ByteStream::SpaceAvailable()
-    virtual size_type       SpaceAvailable()                        const _NOEXCEPT;
+    virtual size_type       SpaceAvailable()  const _NOEXCEPT OVERRIDE;
     
     ///
     /// @copydoc ByteStream::IsOpen()
-    virtual bool            IsOpen()                                const _NOEXCEPT;
+    virtual bool            IsOpen()          const _NOEXCEPT OVERRIDE;
     /**
      Opens the stream for reading and/or writing a file at a given path.
      @param path The filesystem path to the file to access.
@@ -548,14 +548,14 @@ public:
     virtual bool            Open(const string& path, std::ios::openmode mode = std::ios::in | std::ios::out);
     ///
     /// @copydoc ByteStream::Close()
-    virtual void            Close();
+    virtual void            Close() OVERRIDE;
     
     ///
     /// @copydoc ByteStream::ReadBytes()
-    virtual size_type       ReadBytes(void* buf, size_type len);
+    virtual size_type       ReadBytes(void* buf, size_type len) OVERRIDE;
     ///
     /// @copydoc ByteStream::WriteBytes()
-    virtual size_type       WriteBytes(const void* buf, size_type len);
+    virtual size_type       WriteBytes(const void* buf, size_type len) OVERRIDE;
     
     /**
      Seek to a position within the target file.
@@ -619,14 +619,14 @@ private:
 public:
     ///
     /// @copydoc ByteStream::BytesAvailable()
-    virtual size_type       BytesAvailable()                        _NOEXCEPT;
+    virtual size_type       BytesAvailable()  _NOEXCEPT OVERRIDE;
     ///
     /// @copydoc ByteStream::SpaceAvailable
-    virtual size_type       SpaceAvailable()                        const _NOEXCEPT;
+    virtual size_type       SpaceAvailable()  const _NOEXCEPT OVERRIDE;
     
     ///
     /// @copydoc ByteStream::IsOpen()
-    virtual bool            IsOpen()                                const _NOEXCEPT;
+    virtual bool            IsOpen()          const _NOEXCEPT OVERRIDE;
     /**
      Opens a file within an archive and attaches the stream.
      @param archive The Zip arrchive containing the target file.
@@ -637,14 +637,14 @@ public:
     virtual bool            Open(struct zip* archive, const string& path, int zipFlags=0);
     ///
     /// @copydoc ByteStream::Close()
-    virtual void            Close();
+    virtual void            Close() OVERRIDE;
     
     ///
     /// @copydoc ByteStream::ReadBytes()
-    virtual size_type       ReadBytes(void* buf, size_type len);
+    virtual size_type       ReadBytes(void* buf, size_type len) OVERRIDE;
     ///
     /// @copydoc ByteStream::WriteBytes()
-	virtual size_type       WriteBytes(const void* buf, size_type len);
+	virtual size_type       WriteBytes(const void* buf, size_type len) OVERRIDE;
     
     /**
      Seek to a position within the target file.

--- a/ePub3/utilities/error_handler.cpp
+++ b/ePub3/utilities/error_handler.cpp
@@ -132,7 +132,7 @@ std::string epub_spec_error::__init(const std::error_code& code, std::string wha
             what += ": ";
         what += code.message();
     }
-    return std::move(what);
+    return what;
 }
 epub_spec_error::epub_spec_error(EPUBError __ev, const std::string& __what_arg)
   : std::runtime_error(__init(std::error_code(static_cast<int>(__ev), epub_spec_category()), __what_arg)),

--- a/ePub3/utilities/iri.cpp
+++ b/ePub3/utilities/iri.cpp
@@ -63,9 +63,9 @@ IRI::IRI(const string& nameID, const string& namespacedString) :
 #if EPUB_COMPILER_SUPPORTS(CXX_INITIALIZER_LISTS)
     _urnComponents({gURNScheme, nameID, namespacedString}),
 #endif
-    _pureIRI(_Str("urn:", nameID, ":", namespacedString)),
-    _url(make_unique<GURL>(_pureIRI.stl_str()))
+    _pureIRI(_Str("urn:", nameID, ":", namespacedString))
 {
+    _url = make_unique<GURL>(_pureIRI.stl_str());
 #if !EPUB_COMPILER_SUPPORTS(CXX_INITIALIZER_LISTS)
     _urnComponents.push_back(gURNScheme);
     _urnComponents.push_back(nameID);

--- a/ePub3/xml/utilities/io.h
+++ b/ePub3/xml/utilities/io.h
@@ -154,8 +154,8 @@ public:
     virtual size_t offset() const OVERRIDE { return size_t(_input.tellg()); }
     
 protected:
-    virtual size_t read(uint8_t * buf, size_t len);
-    virtual bool close();
+    virtual size_t read(uint8_t * buf, size_t len) OVERRIDE;
+    virtual bool close() OVERRIDE;
     
     std::istream &  _input;
     
@@ -175,8 +175,8 @@ public:
     virtual size_t offset() const OVERRIDE { return size_t(_output.tellp()); }
     
 protected:
-    virtual bool write(const uint8_t * buffer, size_t len);
-    virtual bool close();
+    virtual bool write(const uint8_t * buffer, size_t len) OVERRIDE;
+    virtual bool close() OVERRIDE;
     
     std::ostream &  _output;
     


### PR DESCRIPTION
**What's this do?**
Fixes or silences all warnings for simulator and device architectures on the branch **`feature/drm`** currently used by SimplyE.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2536
The number of warnings we have at every single build is large enough (> 100) to hide any new warnings we might introduce while developing new features. This is quite dangerous. The fact that many of these warnings originate from 3rd party libraries (albeit modified) that we are not changing on a day-to-day basis is even more of a reason to address them or silence them once and for all. Another reason to be pretty aggressive here is because we are moving away from readium 1 anyway.

**How should this be tested? / Do these changes have associated tests?**
I did run some quick tests such as opening up a book in SimplyE and browsing around a few pages to verify I didn't break anything egregious.

**Dependencies for merging? Releasing to production?**
I verified that Android devs are not affected by this, or at least they don't care much since they are already in the process to move to R2. We will need to update the commit SimplyE is pointing at.

**Has the application documentation been updated for these changes?**
I added a lot of explanations in the commit messages.

**Did someone actually run this code to verify it works?**
@ettore 