### PR TITLE
SIMPLY-3622 Fix failing decryption of files with names containing space character

### DIFF
--- a/ePub3/ePub/container.cpp
+++ b/ePub3/ePub/container.cpp
@@ -300,9 +300,15 @@ void Container::LoadEncryption()
 }
 shared_ptr<EncryptionInfo> Container::EncryptionInfoForPath(const string &path) const
 {
+    // Compare encryption path with URI-encoded and decoded paths
+    url_canon::RawCanonOutputW<256> output;
+    url_util::DecodeURLEscapeSequences(path.c_str(), static_cast<int>(path.utf8_size()), &output);
+    string decodedPath(output.data(), output.length());
+
     for ( auto item : _encryption )
     {
-        if ( item->Path() == path )
+        string itemPath = item->Path();
+        if ( itemPath == path || itemPath == decodedPath )
             return item;
     }
     


### PR DESCRIPTION
**What's this do?**
Fixes decryption of files with names containing URI-escaped characters (e.g., spaces, "Chapter Two.html" / "Chapter%20Two.html").

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3622
The issue is fully described in the ticket, in short: when manifest items contain URI-escaped file names (e.g., "Chapter%20Two.html") and `encryption.xml` contains unescaped file names ("Chapter Two.html") decryption doesn't work. The fix compares manifest item file name with both escaped and unescaped versions of the file name.

**How should this be tested? / Do these changes have associated tests?**
After updating `readium-sdk` in your local `develop` branch of SimplyE, follow the steps described under "Acceptance Criteria" in the ticket. Please make sure R2 reader is disabled before testing. Android version should also be affected by the fix.

**Dependencies for merging? Releasing to production?**
Yes

**Has the application documentation been updated for these changes?**
Yes

**Did someone actually run this code to verify it works?**
@vladimirfedorov 