### PR TITLE
IOS-278 Fix simulator build on apple silicon macs

### DIFF
--- a/Platform/Apple/ePub3.xcodeproj/project.pbxproj
+++ b/Platform/Apple/ePub3.xcodeproj/project.pbxproj
@@ -2341,6 +2341,7 @@
 			buildSettings = {
 				CLANG_WARN_UNREACHABLE_CODE = NO;
 				DSTROOT = /tmp/ePub3_iOS.dst;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "../../ePub3-iOS/ePub3-iOS-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (


### PR DESCRIPTION
Excluding arm64 arch from simulator Debug builds because SimplyE can't currently be run natively on arm64 Macs.