### PR TITLE
IOS-575 Silence 2 C++ deprecations

### DIFF
--- a/ePub3/ePub/filter_manager.h
+++ b/ePub3/ePub/filter_manager.h
@@ -70,12 +70,15 @@ public:
         
     };
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     struct PriorityOrderHighToLow : public std::binary_function<Record, Record, bool>
     {
         bool operator()(const Record& __a, const Record& __b) {
             return __b < __a;
         }
     };
+#pragma diagnostic pop
     
     virtual ~FilterManager() {}
     

--- a/ePub3/utilities/executor.h
+++ b/ePub3/utilities/executor.h
@@ -568,6 +568,8 @@ struct __timed_closure_less;
 typedef std::pair<std::chrono::system_clock::time_point, executor::closure_type>                timed_closure;
 typedef std::priority_queue<timed_closure, std::vector<timed_closure>, __timed_closure_less>    timed_closure_queue;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 struct __timed_closure_less : std::binary_function<timed_closure, timed_closure, bool>
 {
     inline FORCE_INLINE
@@ -576,6 +578,7 @@ struct __timed_closure_less : std::binary_function<timed_closure, timed_closure,
             return __lhs.first < __rhs.first;
         }
 };
+#pragma clang diagnostic pop
 
 class __thread_pool_impl_stdcpp
 {


### PR DESCRIPTION
While it's not good practice to silence deprecations, in this case it might be detrimental to change this code since any change might interfere with how AdobeDRM works, and we have no control over the latter.